### PR TITLE
Fix image existence check in s2i-light.sh

### DIFF
--- a/s2i-light.sh
+++ b/s2i-light.sh
@@ -60,7 +60,7 @@ _s2i_usage()
     local img_name=$1; shift
     local s2i_args="$*";
     local usage_command="/usr/libexec/s2i/usage"
-    $(_) run --rm "$img_name" bash -c "$usage_command"
+    $(_get_runtime) run --rm "$img_name" bash -c "$usage_command"
 }
 
 _s2i_build_as_df_help() {

--- a/s2i-light.sh
+++ b/s2i-light.sh
@@ -60,7 +60,7 @@ _s2i_usage()
     local img_name=$1; shift
     local s2i_args="$*";
     local usage_command="/usr/libexec/s2i/usage"
-    $(_get_runtime) run --rm "$img_name" bash -c "$usage_command"
+    $(_) run --rm "$img_name" bash -c "$usage_command"
 }
 
 _s2i_build_as_df_help() {
@@ -132,7 +132,7 @@ _s2i_build_as_df()
     cd "$tmpdir"
 
     # Check if the image is available locally and try to pull it if it is not
-    $(_get_runtime) images | grep -q ^"${src_image}\s" || echo "$s2i_args" | grep -q -e "pull-policy=never" -e "-p=never" || $(_get_runtime) pull "$src_image"
+    $(_get_runtime) image exists "$src_image" || echo "$s2i_args" | grep -q -e "pull-policy=never" -e "-p=never" || $(_get_runtime) pull "$src_image"
     user=$($(_get_runtime) inspect -f "{{.Config.User}}" "$src_image")
 
     # Default to root if no user is set by the image

--- a/s2i-light.sh
+++ b/s2i-light.sh
@@ -132,7 +132,7 @@ _s2i_build_as_df()
     cd "$tmpdir"
 
     # Check if the image is available locally and try to pull it if it is not
-    $(_get_runtime) image exists "$src_image" || echo "$s2i_args" | grep -q -e "pull-policy=never" -e "-p=never" || $(_get_runtime) pull "$src_image"
+    $(_get_runtime) image inspect "$src_image" >/dev/null 2>&1 || echo "$s2i_args" | grep -q -e "pull-policy=never" -e "-p=never" || $(_get_runtime) pull "$src_image"
     user=$($(_get_runtime) inspect -f "{{.Config.User}}" "$src_image")
 
     # Default to root if no user is set by the image


### PR DESCRIPTION

Making a small fix to a line in s2i-light.sh that that causing errors when trying to use locally built images(e.g., localhost/my-app:latest).  The current implementation will fail to see the image and attempt to pull from a remote repo.  Instead of using grep with "podman images", it now uses [podman image exists](https://docs.podman.io/en/latest/markdown/podman-image-exists.1.html).  This should work exactly the same but less likely to break when supplying a localhost image.  This is my first pull request to a public repo, so please let me know if I'm missing anything.

### Error example:
A command like this:
./s2i-light.sh build <path to repo> my-app:latest test-output-image
Results in this output:
Trying to pull localhost/my-app:latest... WARN[0000] Failed, retrying in 1s ... (1/3). Error: initializing source docker://localhost/my-app:latest: pinging container registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of source image detection during incremental builds, reducing cases where builds would incorrectly pull or skip pulling based on local image availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->